### PR TITLE
Update main for performance.

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -4,10 +4,10 @@ package;
 
 #if (!flash)
 	import openfl.utils.AssetLibrary;
-	import openfl.display.Sprite;
+	import openfl.display.DisplayObjectContainer;
 #else
 	import openfl.Assets;
-	import flash.display.Sprite;
+	import flash.display.DisplayObjectContainer;
 #end
 #if sys
 	import sys.FileSystem;
@@ -56,7 +56,7 @@ import platform.file.BrowserBase;
  * 
  */
 
-class Main extends Sprite 
+class Main extends DisplayObjectContainer 
 {
 	private var controlScheme:ControlBase; //Touch/Mouse detection
 	private var KeyboardControl:KeyControl; //Global keyboard control
@@ -78,6 +78,8 @@ class Main extends Sprite
 	public function new() 
 	{
 		super();
+		//Main is not a button
+		mouseEnabled = false;
 		
 		Common.gCode = this; //This class, allows for easy access across rest of program. Common.gCode.doTheThingYouNeed();
 		


### PR DESCRIPTION
MouseEnabled will reduce the background overhead, and if Lib.current is handling mouse up and down then you could also set mouseChildren false as well. Display Object Container is better than sprite if you do not need a this.graphics property.